### PR TITLE
Add stashing of uncommitted changes in GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,12 @@ jobs:
         with:
           files: .gh-pages/*.tgz
 
+      - name: Stash changes before branch switch
+        run: |
+          # Stash any uncommitted changes (like Chart.yaml modifications)
+          git add -A
+          git stash save "Chart.yaml version changes" || true
+
       - name: Checkout gh-pages branch
         run: |
           # Configure git


### PR DESCRIPTION
- Introduced a step to stash any uncommitted changes before switching to the gh-pages branch, specifically targeting modifications in Chart.yaml.
- This enhancement ensures that local changes are preserved during the workflow execution, improving the reliability of the release process.