### PR TITLE
Add multi-architecture support for Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Build stage
 FROM golang:1.24-alpine AS builder
 
+# Add build arguments for multi-arch support
+ARG TARGETOS
+ARG TARGETARCH
+
 # Install build dependencies
 RUN apk add --no-cache git make
 
@@ -16,8 +20,8 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+# Build the binary for the target platform
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-w -s -X main.version=$(git describe --tags --always --dirty) \
     -X main.commit=$(git rev-parse HEAD) \
     -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,22 @@ docker-build:
 	@echo "Building Docker image..."
 	docker build -t $(DOCKER_IMAGE):$(VERSION) -t $(DOCKER_IMAGE):latest .
 
+## docker-buildx: Build multi-arch Docker image with buildx
+docker-buildx:
+	@echo "Building multi-arch Docker image..."
+	docker buildx build --platform linux/amd64,linux/arm64 \
+		-t $(DOCKER_IMAGE):$(VERSION) \
+		-t $(DOCKER_IMAGE):latest \
+		--load .
+
+## docker-buildx-push: Build and push multi-arch Docker image
+docker-buildx-push:
+	@echo "Building and pushing multi-arch Docker image..."
+	docker buildx build --platform linux/amd64,linux/arm64 \
+		-t $(DOCKER_IMAGE):$(VERSION) \
+		-t $(DOCKER_IMAGE):latest \
+		--push .
+
 ## docker-push: Push Docker image
 docker-push: docker-build
 	@echo "Pushing Docker image..."

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ While the original Python-based kube-janitor works well, this Go implementation 
 
 ## Installation
 
+> **Note**: Docker images are available for both `linux/amd64` and `linux/arm64` architectures.
+
 ### Using Helm (Recommended)
 
 ```bash
@@ -243,8 +245,14 @@ kube-janitor-go exposes Prometheus metrics on the `/metrics` endpoint:
 # Build binary
 make build
 
-# Build Docker image
+# Build Docker image (single architecture)
 make docker-build
+
+# Build multi-architecture Docker image (linux/amd64, linux/arm64)
+make docker-buildx
+
+# Build and push multi-architecture Docker image
+make docker-buildx-push
 
 # Run all tests
 make test


### PR DESCRIPTION
- Updated Dockerfile to use build arguments for TARGETOS and TARGETARCH, enabling builds for different architectures.
- Added new Makefile targets for building and pushing multi-arch Docker images using docker buildx.
- Updated README.md to include instructions for building multi-arch images and note on available architectures.