### PR TITLE
Add extended duration parsing and related tests

### DIFF
--- a/internal/janitor/janitor.go
+++ b/internal/janitor/janitor.go
@@ -3,6 +3,9 @@ package janitor
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -302,7 +305,7 @@ func (j *Janitor) processItem(ctx context.Context, item WorkItem) {
 func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 	// Check TTL annotation
 	if ttl, ok := obj.GetAnnotations()[annotationTTL]; ok {
-		duration, err := time.ParseDuration(ttl)
+		duration, err := parseExtendedDuration(ttl)
 		if err != nil {
 			logrus.WithError(err).WithField("ttl", ttl).Warn("Invalid TTL format")
 			return false, ""
@@ -377,6 +380,74 @@ func parseExpirationTime(expires string) (time.Time, error) {
 	}
 
 	return time.Time{}, fmt.Errorf("unable to parse expiration time: %s", expires)
+}
+
+// parseExtendedDuration parses duration strings with extended units:
+// - Standard Go units: h, m, s, ms, us, ns
+// - Extended units: d (days), w (weeks), month/months
+// Examples: "7d", "2w", "1month", "2w3d", "1month2w3d12h30m"
+func parseExtendedDuration(s string) (time.Duration, error) {
+	// First try standard Go duration parsing
+	if d, err := time.ParseDuration(s); err == nil {
+		return d, nil
+	}
+
+	// Extended parsing with regex
+	re := regexp.MustCompile(`(\d+(?:\.\d+)?)\s*(months?|w|d|h|m|s|ms|us|µs|ns)`)
+	matches := re.FindAllStringSubmatch(s, -1)
+
+	if len(matches) == 0 {
+		return 0, fmt.Errorf("invalid duration format: %s", s)
+	}
+
+	var totalDuration time.Duration
+
+	for _, match := range matches {
+		value, err := strconv.ParseFloat(match[1], 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid number in duration: %s", match[1])
+		}
+
+		unit := match[2]
+		var unitDuration time.Duration
+
+		switch unit {
+		case "month", "months":
+			// Approximate month as 30 days
+			unitDuration = time.Duration(value * 30 * 24 * float64(time.Hour))
+		case "w":
+			unitDuration = time.Duration(value * 7 * 24 * float64(time.Hour))
+		case "d":
+			unitDuration = time.Duration(value * 24 * float64(time.Hour))
+		case "h":
+			unitDuration = time.Duration(value * float64(time.Hour))
+		case "m":
+			unitDuration = time.Duration(value * float64(time.Minute))
+		case "s":
+			unitDuration = time.Duration(value * float64(time.Second))
+		case "ms":
+			unitDuration = time.Duration(value * float64(time.Millisecond))
+		case "us", "µs":
+			unitDuration = time.Duration(value * float64(time.Microsecond))
+		case "ns":
+			unitDuration = time.Duration(value * float64(time.Nanosecond))
+		default:
+			return 0, fmt.Errorf("unknown time unit: %s", unit)
+		}
+
+		totalDuration += unitDuration
+	}
+
+	// Verify we consumed the entire string (ignoring whitespace)
+	consumed := ""
+	for _, match := range matches {
+		consumed += match[0]
+	}
+	if strings.ReplaceAll(s, " ", "") != strings.ReplaceAll(consumed, " ", "") {
+		return 0, fmt.Errorf("invalid duration format: %s", s)
+	}
+
+	return totalDuration, nil
 }
 
 func contains(slice []string, item string) bool {

--- a/internal/janitor/janitor_test.go
+++ b/internal/janitor/janitor_test.go
@@ -343,3 +343,241 @@ func TestContains(t *testing.T) {
 		})
 	}
 }
+
+func TestParseExtendedDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+		wantErr  bool
+	}{
+		// Standard Go durations (backward compatibility)
+		{
+			name:     "standard hours",
+			input:    "24h",
+			expected: 24 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "standard minutes",
+			input:    "30m",
+			expected: 30 * time.Minute,
+			wantErr:  false,
+		},
+		{
+			name:     "standard combined",
+			input:    "1h30m",
+			expected: 90 * time.Minute,
+			wantErr:  false,
+		},
+		// Extended durations - days
+		{
+			name:     "single day",
+			input:    "1d",
+			expected: 24 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "multiple days",
+			input:    "7d",
+			expected: 7 * 24 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "fractional days",
+			input:    "1.5d",
+			expected: 36 * time.Hour,
+			wantErr:  false,
+		},
+		// Extended durations - weeks
+		{
+			name:     "single week",
+			input:    "1w",
+			expected: 7 * 24 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "multiple weeks",
+			input:    "2w",
+			expected: 14 * 24 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "fractional weeks",
+			input:    "0.5w",
+			expected: 84 * time.Hour,
+			wantErr:  false,
+		},
+		// Extended durations - months
+		{
+			name:     "single month",
+			input:    "1month",
+			expected: 30 * 24 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "single month plural",
+			input:    "1months",
+			expected: 30 * 24 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "multiple months",
+			input:    "3months",
+			expected: 90 * 24 * time.Hour,
+			wantErr:  false,
+		},
+		// Combined durations
+		{
+			name:     "weeks and days",
+			input:    "2w3d",
+			expected: 17 * 24 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "month week and days",
+			input:    "1month1w2d",
+			expected: 39 * 24 * time.Hour,
+			wantErr:  false,
+		},
+		{
+			name:     "complex combination",
+			input:    "1month2w3d12h30m",
+			expected: 47*24*time.Hour + 12*time.Hour + 30*time.Minute,
+			wantErr:  false,
+		},
+		{
+			name:     "with spaces",
+			input:    "2w 3d 12h",
+			expected: 17*24*time.Hour + 12*time.Hour,
+			wantErr:  false,
+		},
+		// Error cases
+		{
+			name:     "invalid format",
+			input:    "invalid",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid unit",
+			input:    "5x",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid number",
+			input:    "abcd",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "mixed invalid",
+			input:    "2w3x",
+			expected: 0,
+			wantErr:  true,
+		},
+		// Edge cases
+		{
+			name:     "zero duration",
+			input:    "0d",
+			expected: 0,
+			wantErr:  false,
+		},
+		{
+			name:     "very small duration",
+			input:    "1ms",
+			expected: time.Millisecond,
+			wantErr:  false,
+		},
+		{
+			name:     "microseconds with µ",
+			input:    "100µs",
+			expected: 100 * time.Microsecond,
+			wantErr:  false,
+		},
+		{
+			name:     "microseconds with us",
+			input:    "100us",
+			expected: 100 * time.Microsecond,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExtendedDuration(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseExtendedDuration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("parseExtendedDuration() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestParseExtendedDurationRealWorld tests real-world scenarios
+func TestParseExtendedDurationRealWorld(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotation  string
+		ageInHours  float64
+		shouldMatch bool
+	}{
+		{
+			name:        "7 day TTL, 5 day old resource",
+			annotation:  "7d",
+			ageInHours:  120, // 5 days
+			shouldMatch: false,
+		},
+		{
+			name:        "7 day TTL, 8 day old resource",
+			annotation:  "7d",
+			ageInHours:  192, // 8 days
+			shouldMatch: true,
+		},
+		{
+			name:        "2 week TTL, 10 day old resource",
+			annotation:  "2w",
+			ageInHours:  240, // 10 days
+			shouldMatch: false,
+		},
+		{
+			name:        "1 month TTL, 35 day old resource",
+			annotation:  "1month",
+			ageInHours:  840, // 35 days
+			shouldMatch: true,
+		},
+		{
+			name:        "complex TTL, just under limit",
+			annotation:  "1w3d12h",
+			ageInHours:  251, // Just under 10.5 days
+			shouldMatch: false,
+		},
+		{
+			name:        "complex TTL, just over limit",
+			annotation:  "1w3d12h",
+			ageInHours:  253, // Just over 10.5 days
+			shouldMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			duration, err := parseExtendedDuration(tt.annotation)
+			if err != nil {
+				t.Fatalf("Failed to parse duration: %v", err)
+			}
+
+			age := time.Duration(tt.ageInHours * float64(time.Hour))
+			shouldDelete := age > duration
+
+			if shouldDelete != tt.shouldMatch {
+				t.Errorf("Expected shouldDelete=%v for age=%v and TTL=%v, but got %v",
+					tt.shouldMatch, age, duration, shouldDelete)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Implemented `parseExtendedDuration` function to handle standard and extended duration formats, including days, weeks, and months.
- Updated the `shouldDelete` method in the Janitor to utilize the new duration parsing function.
- Added comprehensive unit tests for `parseExtendedDuration` covering various valid and invalid cases, as well as real-world scenarios for TTL annotations.