### PR TITLE
Make sure metric cardinality is finite

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ kube-janitor-go exposes Prometheus metrics on the `/metrics` endpoint:
 - `kube_janitor_resources_deleted_total`: Total number of resources deleted
 - `kube_janitor_resources_evaluated_total`: Total number of resources evaluated
 - `kube_janitor_cleanup_duration_seconds`: Histogram of cleanup run durations
+- `kube_janitor_ttl_deletion_lag_seconds`: Histogram of delay between TTL expiration time and successful resource deletion
 - `kube_janitor_errors_total`: Total number of errors encountered
 
 ## Events

--- a/internal/janitor/janitor.go
+++ b/internal/janitor/janitor.go
@@ -97,6 +97,7 @@ type deletionDecision struct {
 	shouldDelete    bool
 	reason          string
 	detailedMessage string
+	ttlDeadline     time.Time
 }
 
 // New creates a new Janitor instance
@@ -369,6 +370,13 @@ func (j *Janitor) processItem(ctx context.Context, item WorkItem) {
 
 	logger.Info("Resource deleted")
 	metrics.ResourcesDeleted.WithLabelValues(item.Resource.Resource, decision.reason).Inc()
+	if !decision.ttlDeadline.IsZero() {
+		ttlLag := time.Since(decision.ttlDeadline)
+		if ttlLag < 0 {
+			ttlLag = 0
+		}
+		metrics.TTLDeletionLag.WithLabelValues(item.Resource.Resource, decision.reason).Observe(ttlLag.Seconds())
+	}
 
 	// Create event for successful deletion
 	eventMessage := fmt.Sprintf("Deleted %s %s/%s - %s",
@@ -377,17 +385,20 @@ func (j *Janitor) processItem(ctx context.Context, item WorkItem) {
 }
 
 // evaluateDeleteIfMaxAge checks if resource should be deleted based on max age
-func (j *Janitor) evaluateDeleteIfMaxAge(value string, obj *unstructured.Unstructured) (bool, string, error) {
+func (j *Janitor) evaluateDeleteIfMaxAge(value string, obj *unstructured.Unstructured) (bool, string, time.Time, error) {
 	duration, err := ParseExtendedDuration(value)
 	if err != nil {
-		return false, "", fmt.Errorf("invalid duration format: %w", err)
+		return false, "", time.Time{}, fmt.Errorf("invalid duration format: %w", err)
 	}
 
-	age := time.Since(obj.GetCreationTimestamp().Time)
-	if age > duration {
-		return true, fmt.Sprintf("Delete max-age policy triggered (age: %s, max-age: %s)", age, duration), nil
+	createdAt := obj.GetCreationTimestamp().Time
+	now := time.Now()
+	age := now.Sub(createdAt)
+	ttlDeadline := createdAt.Add(duration)
+	if now.After(ttlDeadline) {
+		return true, fmt.Sprintf("Delete max-age policy triggered (age: %s, max-age: %s)", age, duration), ttlDeadline, nil
 	}
-	return false, "", nil
+	return false, "", time.Time{}, nil
 }
 
 // evaluateDeleteIfDate checks if resource should be deleted based on expiration date
@@ -435,7 +446,7 @@ func (j *Janitor) evaluateArchiveIfDate(value string, obj *unstructured.Unstruct
 }
 
 // evaluateDeleteIfIdle checks if resource should be deleted based on idle time
-func (j *Janitor) evaluateDeleteIfIdle(value string, obj *unstructured.Unstructured) (bool, string, error) {
+func (j *Janitor) evaluateDeleteIfIdle(value string, obj *unstructured.Unstructured) (bool, string, time.Time, error) {
 	logrus.WithFields(logrus.Fields{
 		"resource":             obj.GetKind(),
 		"namespace":            obj.GetNamespace(),
@@ -461,7 +472,7 @@ func (j *Janitor) evaluateDeleteIfIdle(value string, obj *unstructured.Unstructu
 			"namespace": obj.GetNamespace(),
 			"name":      obj.GetName(),
 		}).Debug("Delete-if-idle policy ignored: no lastUsedAt annotation found")
-		return false, "", nil
+		return false, "", time.Time{}, nil
 	}
 
 	lastUsedAt, err := time.Parse(time.RFC3339, lastUsedAtStr)
@@ -472,7 +483,7 @@ func (j *Janitor) evaluateDeleteIfIdle(value string, obj *unstructured.Unstructu
 			"name":          obj.GetName(),
 			"lastUsedAtStr": lastUsedAtStr,
 		}).Debug("Failed to parse lastUsedAt timestamp")
-		return false, "", fmt.Errorf("invalid lastUsedAt format: %w", err)
+		return false, "", time.Time{}, fmt.Errorf("invalid lastUsedAt format: %w", err)
 	}
 
 	duration, err := ParseExtendedDuration(value)
@@ -483,24 +494,26 @@ func (j *Janitor) evaluateDeleteIfIdle(value string, obj *unstructured.Unstructu
 			"name":      obj.GetName(),
 			"value":     value,
 		}).Debug("Failed to parse duration")
-		return false, "", fmt.Errorf("invalid duration format: %w", err)
+		return false, "", time.Time{}, fmt.Errorf("invalid duration format: %w", err)
 	}
 
-	idleTime := time.Since(lastUsedAt)
+	now := time.Now()
+	idleTime := now.Sub(lastUsedAt)
+	ttlDeadline := lastUsedAt.Add(duration)
 	logrus.WithFields(logrus.Fields{
 		"resource":     obj.GetKind(),
 		"namespace":    obj.GetNamespace(),
 		"name":         obj.GetName(),
 		"idleTime":     idleTime,
 		"duration":     duration,
-		"shouldDelete": idleTime > duration,
+		"shouldDelete": now.After(ttlDeadline),
 		"lastUsedAt":   lastUsedAt,
 	}).Debug("Evaluating idle time")
 
-	if idleTime > duration {
-		return true, fmt.Sprintf("Delete idle policy triggered (idle: %s, max-idle: %s)", idleTime, duration), nil
+	if now.After(ttlDeadline) {
+		return true, fmt.Sprintf("Delete idle policy triggered (idle: %s, max-idle: %s)", idleTime, duration), ttlDeadline, nil
 	}
-	return false, "", nil
+	return false, "", time.Time{}, nil
 }
 
 // findAnnotationsWithPrefix finds all annotations that start with the given prefix
@@ -539,7 +552,7 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) deletionDecision 
 		"maxAgeAnnotations": len(maxAgeAnnotations),
 	}).Debug("Checking delete-if-max-age annotations")
 	for annotationKey, annotationValue := range maxAgeAnnotations {
-		shouldDelete, detailedMessage, err := j.evaluateDeleteIfMaxAge(annotationValue, obj)
+		shouldDelete, detailedMessage, ttlDeadline, err := j.evaluateDeleteIfMaxAge(annotationValue, obj)
 		if err != nil {
 			logrus.WithError(err).WithFields(logrus.Fields{
 				"annotation": annotationKey,
@@ -552,6 +565,7 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) deletionDecision 
 				shouldDelete:    true,
 				reason:          deletionReasonDeleteIfMaxAge,
 				detailedMessage: fmt.Sprintf("%s (annotation: %s)", detailedMessage, annotationKey),
+				ttlDeadline:     ttlDeadline,
 			}
 		}
 	}
@@ -573,7 +587,7 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) deletionDecision 
 			"annotation": annotationKey,
 			"value":      annotationValue,
 		}).Debug("Processing delete-if-idle annotation")
-		shouldDelete, detailedMessage, err := j.evaluateDeleteIfIdle(annotationValue, obj)
+		shouldDelete, detailedMessage, ttlDeadline, err := j.evaluateDeleteIfIdle(annotationValue, obj)
 		if err != nil {
 			logrus.WithError(err).WithFields(logrus.Fields{
 				"annotation": annotationKey,
@@ -586,6 +600,7 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) deletionDecision 
 				shouldDelete:    true,
 				reason:          deletionReasonDeleteIfIdle,
 				detailedMessage: fmt.Sprintf("%s (annotation: %s)", detailedMessage, annotationKey),
+				ttlDeadline:     ttlDeadline,
 			}
 		}
 	}
@@ -659,12 +674,16 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) deletionDecision 
 			return deletionDecision{}
 		}
 
-		age := time.Since(obj.GetCreationTimestamp().Time)
-		if age > duration {
+		createdAt := obj.GetCreationTimestamp().Time
+		now := time.Now()
+		age := now.Sub(createdAt)
+		ttlDeadline := createdAt.Add(duration)
+		if now.After(ttlDeadline) {
 			return deletionDecision{
 				shouldDelete:    true,
 				reason:          deletionReasonLegacyTTL,
 				detailedMessage: fmt.Sprintf("Legacy TTL expired (age: %s, ttl: %s)", age, duration),
+				ttlDeadline:     ttlDeadline,
 			}
 		}
 		return deletionDecision{}
@@ -697,12 +716,16 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) deletionDecision 
 	}).Debug("Checking CEL rules")
 	if j.RuleEngine != nil {
 		if rule, ttl := j.RuleEngine.Evaluate(obj); rule != nil {
-			age := time.Since(obj.GetCreationTimestamp().Time)
-			if age > ttl {
+			createdAt := obj.GetCreationTimestamp().Time
+			now := time.Now()
+			age := now.Sub(createdAt)
+			ttlDeadline := createdAt.Add(ttl)
+			if now.After(ttlDeadline) {
 				return deletionDecision{
 					shouldDelete:    true,
 					reason:          deletionReasonRuleTTL,
 					detailedMessage: fmt.Sprintf("Rule '%s' matched (age: %s, ttl: %s)", rule.ID, age, ttl),
+					ttlDeadline:     ttlDeadline,
 				}
 			}
 		}

--- a/internal/janitor/janitor.go
+++ b/internal/janitor/janitor.go
@@ -50,6 +50,15 @@ const (
 	ActionArchive = "archive" // Future implementation
 )
 
+const (
+	deletionReasonDeleteIfMaxAge = "delete_if_max_age"
+	deletionReasonDeleteIfIdle   = "delete_if_idle"
+	deletionReasonDeleteIfDate   = "delete_if_date"
+	deletionReasonLegacyTTL      = "legacy_ttl"
+	deletionReasonLegacyExpires  = "legacy_expires"
+	deletionReasonRuleTTL        = "rule_ttl"
+)
+
 // Config holds the janitor configuration
 type Config struct {
 	DryRun            bool
@@ -82,6 +91,12 @@ type WorkItem struct {
 	Namespace string
 	Name      string
 	Obj       *unstructured.Unstructured
+}
+
+type deletionDecision struct {
+	shouldDelete    bool
+	reason          string
+	detailedMessage string
 }
 
 // New creates a new Janitor instance
@@ -268,7 +283,7 @@ func (j *Janitor) processResources(ctx context.Context, gvr schema.GroupVersionR
 	for _, item := range list.Items {
 		obj := item
 		// Track evaluated resources
-		metrics.ResourcesEvaluated.WithLabelValues(gvr.Resource, namespace).Inc()
+		metrics.ResourcesEvaluated.WithLabelValues(gvr.Resource).Inc()
 
 		j.WorkQueue <- WorkItem{
 			Resource:  gvr,
@@ -305,12 +320,15 @@ func (j *Janitor) processItem(ctx context.Context, item WorkItem) {
 	})
 
 	// Check if resource should be deleted
-	shouldDelete, reason := j.shouldDelete(item.Obj)
-	if !shouldDelete {
+	decision := j.shouldDelete(item.Obj)
+	if !decision.shouldDelete {
 		return
 	}
 
-	logger.WithField("reason", reason).Info("Resource marked for deletion")
+	logger.WithFields(logrus.Fields{
+		"reason":          decision.reason,
+		"detailedMessage": decision.detailedMessage,
+	}).Info("Resource marked for deletion")
 
 	// Create a reference to the object for the event
 	ref := &corev1.ObjectReference{
@@ -325,7 +343,7 @@ func (j *Janitor) processItem(ctx context.Context, item WorkItem) {
 		logger.Info("DRY RUN: Would delete resource")
 		// Create event for dry-run
 		eventMessage := fmt.Sprintf("DRY RUN: Would delete %s %s/%s - %s",
-			item.Resource.Resource, item.Namespace, item.Name, reason)
+			item.Resource.Resource, item.Namespace, item.Name, decision.detailedMessage)
 		j.EventRecorder.Event(ref, corev1.EventTypeNormal, "DryRunDeletion", eventMessage)
 		return
 	}
@@ -350,11 +368,11 @@ func (j *Janitor) processItem(ctx context.Context, item WorkItem) {
 	}
 
 	logger.Info("Resource deleted")
-	metrics.ResourcesDeleted.WithLabelValues(item.Resource.Resource, item.Namespace, reason).Inc()
+	metrics.ResourcesDeleted.WithLabelValues(item.Resource.Resource, decision.reason).Inc()
 
 	// Create event for successful deletion
 	eventMessage := fmt.Sprintf("Deleted %s %s/%s - %s",
-		item.Resource.Resource, item.Namespace, item.Name, reason)
+		item.Resource.Resource, item.Namespace, item.Name, decision.detailedMessage)
 	j.EventRecorder.Event(ref, corev1.EventTypeNormal, "ResourceDeleted", eventMessage)
 }
 
@@ -496,7 +514,10 @@ func findAnnotationsWithPrefix(annotations map[string]string, prefix string) map
 	return result
 }
 
-func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
+// shouldDelete returns a deletion reason that is used as a Prometheus metric label;
+// therefore reason must have a finite set of possible values. Put dynamic context
+// such as ages, TTLs, timestamps, annotation keys, and rule IDs in detailedMessage.
+func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) deletionDecision {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
@@ -518,7 +539,7 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 		"maxAgeAnnotations": len(maxAgeAnnotations),
 	}).Debug("Checking delete-if-max-age annotations")
 	for annotationKey, annotationValue := range maxAgeAnnotations {
-		shouldDelete, reason, err := j.evaluateDeleteIfMaxAge(annotationValue, obj)
+		shouldDelete, detailedMessage, err := j.evaluateDeleteIfMaxAge(annotationValue, obj)
 		if err != nil {
 			logrus.WithError(err).WithFields(logrus.Fields{
 				"annotation": annotationKey,
@@ -527,7 +548,11 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 			continue
 		}
 		if shouldDelete {
-			return true, fmt.Sprintf("%s (annotation: %s)", reason, annotationKey)
+			return deletionDecision{
+				shouldDelete:    true,
+				reason:          deletionReasonDeleteIfMaxAge,
+				detailedMessage: fmt.Sprintf("%s (annotation: %s)", detailedMessage, annotationKey),
+			}
 		}
 	}
 
@@ -548,7 +573,7 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 			"annotation": annotationKey,
 			"value":      annotationValue,
 		}).Debug("Processing delete-if-idle annotation")
-		shouldDelete, reason, err := j.evaluateDeleteIfIdle(annotationValue, obj)
+		shouldDelete, detailedMessage, err := j.evaluateDeleteIfIdle(annotationValue, obj)
 		if err != nil {
 			logrus.WithError(err).WithFields(logrus.Fields{
 				"annotation": annotationKey,
@@ -557,7 +582,11 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 			continue
 		}
 		if shouldDelete {
-			return true, fmt.Sprintf("%s (annotation: %s)", reason, annotationKey)
+			return deletionDecision{
+				shouldDelete:    true,
+				reason:          deletionReasonDeleteIfIdle,
+				detailedMessage: fmt.Sprintf("%s (annotation: %s)", detailedMessage, annotationKey),
+			}
 		}
 	}
 
@@ -570,7 +599,7 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 		"dateAnnotations": len(dateAnnotations),
 	}).Debug("Checking delete-if-date annotations")
 	for annotationKey, annotationValue := range dateAnnotations {
-		shouldDelete, reason, err := j.evaluateDeleteIfDate(annotationValue, obj)
+		shouldDelete, detailedMessage, err := j.evaluateDeleteIfDate(annotationValue, obj)
 		if err != nil {
 			logrus.WithError(err).WithFields(logrus.Fields{
 				"annotation": annotationKey,
@@ -579,7 +608,11 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 			continue
 		}
 		if shouldDelete {
-			return true, fmt.Sprintf("%s (annotation: %s)", reason, annotationKey)
+			return deletionDecision{
+				shouldDelete:    true,
+				reason:          deletionReasonDeleteIfDate,
+				detailedMessage: fmt.Sprintf("%s (annotation: %s)", detailedMessage, annotationKey),
+			}
 		}
 	}
 
@@ -623,14 +656,18 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 		duration, err := ParseExtendedDuration(ttl)
 		if err != nil {
 			logrus.WithError(err).WithField("ttl", ttl).Warn("Invalid TTL format")
-			return false, ""
+			return deletionDecision{}
 		}
 
 		age := time.Since(obj.GetCreationTimestamp().Time)
 		if age > duration {
-			return true, fmt.Sprintf("Legacy TTL expired (age: %s, ttl: %s)", age, duration)
+			return deletionDecision{
+				shouldDelete:    true,
+				reason:          deletionReasonLegacyTTL,
+				detailedMessage: fmt.Sprintf("Legacy TTL expired (age: %s, ttl: %s)", age, duration),
+			}
 		}
-		return false, ""
+		return deletionDecision{}
 	}
 
 	// Fallback to legacy expiration annotation for backward compatibility
@@ -638,13 +675,17 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 		expirationTime, err := parseExpirationTime(expires)
 		if err != nil {
 			logrus.WithError(err).WithField("expires", expires).Warn("Invalid expiration format")
-			return false, ""
+			return deletionDecision{}
 		}
 
 		if time.Now().After(expirationTime) {
-			return true, fmt.Sprintf("Legacy expiration time reached (%s)", expires)
+			return deletionDecision{
+				shouldDelete:    true,
+				reason:          deletionReasonLegacyExpires,
+				detailedMessage: fmt.Sprintf("Legacy expiration time reached (%s)", expires),
+			}
 		}
-		return false, ""
+		return deletionDecision{}
 	}
 
 	// Check rules
@@ -658,7 +699,11 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 		if rule, ttl := j.RuleEngine.Evaluate(obj); rule != nil {
 			age := time.Since(obj.GetCreationTimestamp().Time)
 			if age > ttl {
-				return true, fmt.Sprintf("Rule '%s' matched (age: %s, ttl: %s)", rule.ID, age, ttl)
+				return deletionDecision{
+					shouldDelete:    true,
+					reason:          deletionReasonRuleTTL,
+					detailedMessage: fmt.Sprintf("Rule '%s' matched (age: %s, ttl: %s)", rule.ID, age, ttl),
+				}
 			}
 		}
 	}
@@ -668,7 +713,7 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 		"namespace": obj.GetNamespace(),
 		"name":      obj.GetName(),
 	}).Debug("No deletion conditions met - resource will be kept")
-	return false, ""
+	return deletionDecision{}
 }
 
 func (j *Janitor) getNamespaces(ctx context.Context) ([]string, error) {

--- a/internal/janitor/janitor_test.go
+++ b/internal/janitor/janitor_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blaxel-ai/kube-janitor-go/internal/metrics"
 	"github.com/blaxel-ai/kube-janitor-go/internal/rules"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -85,6 +88,7 @@ func TestShouldDelete(t *testing.T) {
 		wantDelete          bool
 		wantReason          string
 		wantDetailedMessage string
+		wantTTLDeadline     bool
 	}{
 		{
 			name: "Delete-if-max-age expired",
@@ -102,6 +106,7 @@ func TestShouldDelete(t *testing.T) {
 			wantDelete:          true,
 			wantReason:          deletionReasonDeleteIfMaxAge,
 			wantDetailedMessage: "Delete max-age policy triggered",
+			wantTTLDeadline:     true,
 		},
 		{
 			name: "Delete-if-idle expired",
@@ -119,6 +124,7 @@ func TestShouldDelete(t *testing.T) {
 			wantDelete:          true,
 			wantReason:          deletionReasonDeleteIfIdle,
 			wantDetailedMessage: "Delete idle policy triggered",
+			wantTTLDeadline:     true,
 		},
 		{
 			name: "TTL expired",
@@ -136,6 +142,7 @@ func TestShouldDelete(t *testing.T) {
 			wantDelete:          true,
 			wantReason:          deletionReasonLegacyTTL,
 			wantDetailedMessage: "TTL expired",
+			wantTTLDeadline:     true,
 		},
 		{
 			name: "Rule TTL expired",
@@ -152,6 +159,7 @@ func TestShouldDelete(t *testing.T) {
 			wantDelete:          true,
 			wantReason:          deletionReasonRuleTTL,
 			wantDetailedMessage: "Rule 'cleanup-test-pods' matched",
+			wantTTLDeadline:     true,
 		},
 		{
 			name: "TTL not expired",
@@ -342,9 +350,11 @@ func TestShouldDelete(t *testing.T) {
 				assert.Contains(t, gotDecision.detailedMessage, tt.wantDetailedMessage)
 				assert.NotContains(t, gotDecision.detailedMessage, gotDecision.reason,
 					"bounded metric reason should not be reused as the detailed human-readable message")
+				assert.Equal(t, tt.wantTTLDeadline, !gotDecision.ttlDeadline.IsZero())
 			} else {
 				assert.Empty(t, gotDecision.reason)
 				assert.Empty(t, gotDecision.detailedMessage)
+				assert.True(t, gotDecision.ttlDeadline.IsZero())
 			}
 		})
 	}
@@ -406,8 +416,10 @@ func TestProcessItem(t *testing.T) {
 		Obj:       pod,
 	}
 
+	ttlLagSamplesBefore := ttlDeletionLagSampleCount(t, item.Resource.Resource, deletionReasonLegacyTTL)
 	j.processItem(ctx, item)
 	assert.True(t, deleteCalled, "Delete should have been called")
+	assert.Equal(t, ttlLagSamplesBefore+1, ttlDeletionLagSampleCount(t, item.Resource.Resource, deletionReasonLegacyTTL))
 }
 
 func TestProcessItemDryRun(t *testing.T) {
@@ -466,8 +478,44 @@ func TestProcessItemDryRun(t *testing.T) {
 		Obj:       pod,
 	}
 
+	ttlLagSamplesBefore := ttlDeletionLagSampleCount(t, item.Resource.Resource, deletionReasonLegacyTTL)
 	j.processItem(ctx, item)
 	assert.False(t, deleteCalled, "Delete should not have been called in dry-run mode")
+	assert.Equal(t, ttlLagSamplesBefore, ttlDeletionLagSampleCount(t, item.Resource.Resource, deletionReasonLegacyTTL))
+}
+
+func ttlDeletionLagSampleCount(t *testing.T, resource, reason string) uint64 {
+	t.Helper()
+
+	collected := make(chan prometheus.Metric)
+	go func() {
+		metrics.TTLDeletionLag.Collect(collected)
+		close(collected)
+	}()
+
+	var count uint64
+	for metric := range collected {
+		var dtoMetric dto.Metric
+		require.NoError(t, metric.Write(&dtoMetric))
+		if metricHasLabels(&dtoMetric, map[string]string{
+			"resource": resource,
+			"reason":   reason,
+		}) {
+			count += dtoMetric.GetHistogram().GetSampleCount()
+		}
+	}
+	return count
+}
+
+func metricHasLabels(metric *dto.Metric, labels map[string]string) bool {
+	matched := 0
+	for _, label := range metric.GetLabel() {
+		want, ok := labels[label.GetName()]
+		if ok && label.GetValue() == want {
+			matched++
+		}
+	}
+	return matched == len(labels)
 }
 
 func TestGetNamespaces(t *testing.T) {

--- a/internal/janitor/janitor_test.go
+++ b/internal/janitor/janitor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blaxel-ai/kube-janitor-go/internal/rules"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -67,13 +68,58 @@ func TestParseExpirationTime(t *testing.T) {
 
 func TestShouldDelete(t *testing.T) {
 	now := time.Now()
+	ruleEngine, err := rules.New([]rules.Rule{
+		{
+			ID:         "cleanup-test-pods",
+			Resources:  []string{"pods"},
+			Expression: `object.metadata.name == "rule-pod"`,
+			TTL:        "1h",
+		},
+	})
+	require.NoError(t, err)
 
 	tests := []struct {
-		name       string
-		obj        *unstructured.Unstructured
-		wantDelete bool
-		wantReason string
+		name                string
+		obj                 *unstructured.Unstructured
+		ruleEngine          *rules.Engine
+		wantDelete          bool
+		wantReason          string
+		wantDetailedMessage string
 	}{
+		{
+			name: "Delete-if-max-age expired",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name":              "test-pod",
+						"creationTimestamp": now.Add(-2 * time.Hour).Format(time.RFC3339),
+						"annotations": map[string]interface{}{
+							annotationDeleteIfMaxAge: "1h",
+						},
+					},
+				},
+			},
+			wantDelete:          true,
+			wantReason:          deletionReasonDeleteIfMaxAge,
+			wantDetailedMessage: "Delete max-age policy triggered",
+		},
+		{
+			name: "Delete-if-idle expired",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "test-pod",
+						"annotations": map[string]interface{}{
+							annotationDeleteIfIdle: "30m",
+							annotationLastUsedAt:   now.Add(-1 * time.Hour).Format(time.RFC3339),
+						},
+					},
+				},
+			},
+			wantDelete:          true,
+			wantReason:          deletionReasonDeleteIfIdle,
+			wantDetailedMessage: "Delete idle policy triggered",
+		},
 		{
 			name: "TTL expired",
 			obj: &unstructured.Unstructured{
@@ -87,8 +133,25 @@ func TestShouldDelete(t *testing.T) {
 					},
 				},
 			},
-			wantDelete: true,
-			wantReason: "TTL expired",
+			wantDelete:          true,
+			wantReason:          deletionReasonLegacyTTL,
+			wantDetailedMessage: "TTL expired",
+		},
+		{
+			name: "Rule TTL expired",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Pod",
+					"metadata": map[string]interface{}{
+						"name":              "rule-pod",
+						"creationTimestamp": now.Add(-2 * time.Hour).Format(time.RFC3339),
+					},
+				},
+			},
+			ruleEngine:          ruleEngine,
+			wantDelete:          true,
+			wantReason:          deletionReasonRuleTTL,
+			wantDetailedMessage: "Rule 'cleanup-test-pods' matched",
 		},
 		{
 			name: "TTL not expired",
@@ -132,8 +195,9 @@ func TestShouldDelete(t *testing.T) {
 					},
 				},
 			},
-			wantDelete: true,
-			wantReason: "Legacy expiration time reached",
+			wantDelete:          true,
+			wantReason:          deletionReasonLegacyExpires,
+			wantDetailedMessage: "Legacy expiration time reached",
 		},
 		{
 			name: "Expiration time not reached",
@@ -161,8 +225,9 @@ func TestShouldDelete(t *testing.T) {
 					},
 				},
 			},
-			wantDelete: true,
-			wantReason: "Delete date policy triggered",
+			wantDelete:          true,
+			wantReason:          deletionReasonDeleteIfDate,
+			wantDetailedMessage: "Delete date policy triggered",
 		},
 		{
 			name: "Delete-if-date time not reached",
@@ -190,8 +255,9 @@ func TestShouldDelete(t *testing.T) {
 					},
 				},
 			},
-			wantDelete: true,
-			wantReason: "Delete date policy triggered",
+			wantDelete:          true,
+			wantReason:          deletionReasonDeleteIfDate,
+			wantDetailedMessage: "Delete date policy triggered",
 		},
 		{
 			name: "Delete-if-date with -0 suffix",
@@ -205,8 +271,9 @@ func TestShouldDelete(t *testing.T) {
 					},
 				},
 			},
-			wantDelete: true,
-			wantReason: "Delete date policy triggered",
+			wantDelete:          true,
+			wantReason:          deletionReasonDeleteIfDate,
+			wantDetailedMessage: "Delete date policy triggered",
 		},
 		{
 			name: "Delete-if-date-0 with exact format from user",
@@ -234,8 +301,9 @@ func TestShouldDelete(t *testing.T) {
 					},
 				},
 			},
-			wantDelete: true,
-			wantReason: "Delete date policy triggered",
+			wantDelete:          true,
+			wantReason:          deletionReasonDeleteIfDate,
+			wantDetailedMessage: "Delete date policy triggered",
 		},
 		{
 			name: "Archive-if-date annotation (mock - should not delete)",
@@ -266,11 +334,17 @@ func TestShouldDelete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			j := &Janitor{}
-			gotDelete, gotReason := j.shouldDelete(tt.obj)
-			assert.Equal(t, tt.wantDelete, gotDelete)
+			j := &Janitor{RuleEngine: tt.ruleEngine}
+			gotDecision := j.shouldDelete(tt.obj)
+			assert.Equal(t, tt.wantDelete, gotDecision.shouldDelete)
 			if tt.wantDelete && tt.wantReason != "" {
-				assert.Contains(t, gotReason, tt.wantReason)
+				assert.Equal(t, tt.wantReason, gotDecision.reason)
+				assert.Contains(t, gotDecision.detailedMessage, tt.wantDetailedMessage)
+				assert.NotContains(t, gotDecision.detailedMessage, gotDecision.reason,
+					"bounded metric reason should not be reused as the detailed human-readable message")
+			} else {
+				assert.Empty(t, gotDecision.reason)
+				assert.Empty(t, gotDecision.detailedMessage)
 			}
 		})
 	}

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -38,6 +38,16 @@ var (
 		},
 	)
 
+	// TTLDeletionLag is a histogram for the delay between TTL expiry and deletion
+	TTLDeletionLag = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kube_janitor_ttl_deletion_lag_seconds",
+			Help:    "Histogram of delay between TTL expiration time and successful resource deletion",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 20),
+		},
+		[]string{"resource", "reason"},
+	)
+
 	// Errors is a counter for errors
 	Errors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -53,6 +63,7 @@ func init() {
 	prometheus.MustRegister(ResourcesDeleted)
 	prometheus.MustRegister(ResourcesEvaluated)
 	prometheus.MustRegister(CleanupDuration)
+	prometheus.MustRegister(TTLDeletionLag)
 	prometheus.MustRegister(Errors)
 }
 

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -17,7 +17,7 @@ var (
 			Name: "kube_janitor_resources_deleted_total",
 			Help: "Total number of resources deleted",
 		},
-		[]string{"resource", "namespace", "reason"},
+		[]string{"resource", "reason"},
 	)
 
 	// ResourcesEvaluated is a counter for evaluated resources
@@ -26,7 +26,7 @@ var (
 			Name: "kube_janitor_resources_evaluated_total",
 			Help: "Total number of resources evaluated",
 		},
-		[]string{"resource", "namespace"},
+		[]string{"resource"},
 	)
 
 	// CleanupDuration is a histogram for cleanup run durations

--- a/internal/metrics/server_test.go
+++ b/internal/metrics/server_test.go
@@ -25,6 +25,7 @@ func TestMetricsRegistration(t *testing.T) {
 	assert.NotNil(t, ResourcesDeleted)
 	assert.NotNil(t, ResourcesEvaluated)
 	assert.NotNil(t, CleanupDuration)
+	assert.NotNil(t, TTLDeletionLag)
 	assert.NotNil(t, Errors)
 }
 
@@ -117,6 +118,7 @@ func TestMetricsIncrement(t *testing.T) {
 	prometheus.Unregister(ResourcesDeleted)
 	prometheus.Unregister(ResourcesEvaluated)
 	prometheus.Unregister(CleanupDuration)
+	prometheus.Unregister(TTLDeletionLag)
 	prometheus.Unregister(Errors)
 
 	// Re-register metrics
@@ -141,6 +143,14 @@ func TestMetricsIncrement(t *testing.T) {
 			Buckets: prometheus.DefBuckets,
 		},
 	)
+	TTLDeletionLag = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kube_janitor_ttl_deletion_lag_seconds_test",
+			Help:    "Histogram of delay between TTL expiration time and successful resource deletion",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 20),
+		},
+		[]string{"resource", "reason"},
+	)
 	Errors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "kube_janitor_errors_total_test",
@@ -152,11 +162,13 @@ func TestMetricsIncrement(t *testing.T) {
 	prometheus.MustRegister(ResourcesDeleted)
 	prometheus.MustRegister(ResourcesEvaluated)
 	prometheus.MustRegister(CleanupDuration)
+	prometheus.MustRegister(TTLDeletionLag)
 	prometheus.MustRegister(Errors)
 
 	// Test incrementing metrics
 	ResourcesDeleted.WithLabelValues("pods", "ttl_expired").Inc()
 	ResourcesEvaluated.WithLabelValues("pods").Inc()
+	TTLDeletionLag.WithLabelValues("pods", "legacy_ttl").Observe(42)
 	Errors.WithLabelValues("delete_failed").Inc()
 
 	// Test histogram
@@ -171,6 +183,7 @@ func TestMetricsIncrement(t *testing.T) {
 	foundDeleted := false
 	foundEvaluated := false
 	foundDuration := false
+	foundTTLLag := false
 	foundErrors := false
 
 	for _, metric := range metrics {
@@ -187,6 +200,10 @@ func TestMetricsIncrement(t *testing.T) {
 			foundDuration = true
 			assert.Len(t, metric.GetMetric(), 1)
 			assert.Greater(t, metric.GetMetric()[0].GetHistogram().GetSampleCount(), uint64(0))
+		case "kube_janitor_ttl_deletion_lag_seconds_test":
+			foundTTLLag = true
+			assert.Len(t, metric.GetMetric(), 1)
+			assert.Equal(t, uint64(1), metric.GetMetric()[0].GetHistogram().GetSampleCount())
 		case "kube_janitor_errors_total_test":
 			foundErrors = true
 			assert.Len(t, metric.GetMetric(), 1)
@@ -197,5 +214,6 @@ func TestMetricsIncrement(t *testing.T) {
 	assert.True(t, foundDeleted, "ResourcesDeleted metric not found")
 	assert.True(t, foundEvaluated, "ResourcesEvaluated metric not found")
 	assert.True(t, foundDuration, "CleanupDuration metric not found")
+	assert.True(t, foundTTLLag, "TTLDeletionLag metric not found")
 	assert.True(t, foundErrors, "Errors metric not found")
 }

--- a/internal/metrics/server_test.go
+++ b/internal/metrics/server_test.go
@@ -125,14 +125,14 @@ func TestMetricsIncrement(t *testing.T) {
 			Name: "kube_janitor_resources_deleted_total_test",
 			Help: "Total number of resources deleted",
 		},
-		[]string{"resource", "namespace", "reason"},
+		[]string{"resource", "reason"},
 	)
 	ResourcesEvaluated = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "kube_janitor_resources_evaluated_total_test",
 			Help: "Total number of resources evaluated",
 		},
-		[]string{"resource", "namespace"},
+		[]string{"resource"},
 	)
 	CleanupDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
@@ -155,8 +155,8 @@ func TestMetricsIncrement(t *testing.T) {
 	prometheus.MustRegister(Errors)
 
 	// Test incrementing metrics
-	ResourcesDeleted.WithLabelValues("pods", "default", "ttl_expired").Inc()
-	ResourcesEvaluated.WithLabelValues("pods", "default").Inc()
+	ResourcesDeleted.WithLabelValues("pods", "ttl_expired").Inc()
+	ResourcesEvaluated.WithLabelValues("pods").Inc()
 	Errors.WithLabelValues("delete_failed").Inc()
 
 	// Test histogram


### PR DESCRIPTION
- Stopped labeling the "resources evaluated" and "resources deleted" metris with a namespace label (as the number of possible namespace values is infinite).
- Distinguished between a small, discrete set of possible values for "reason" (used as a metric label), and the infinite set of possible values for "detailed message" (which includes exact age and namespace; this information is logged but not used as a metric label).
- Adds the "deletion lag" metric when deleting due to TTL expiry.