### PR TITLE
Stop listing resources per-namespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Flags:
       --max-workers int             Maximum number of concurrent workers (default 10)
       --kube-api-qps float32        Kubernetes API client QPS limit (set 0 to use client-go default) (default 25)
       --kube-api-burst int          Kubernetes API client burst limit (set 0 to use 2x QPS when QPS is set, otherwise client-go default) (default 50)
+      --list-page-limit int         Maximum number of resources to request per paginated Kubernetes list call (default 100)
   -h, --help                        help for kube-janitor-go
 ```
 

--- a/cmd/kube-janitor-go/main.go
+++ b/cmd/kube-janitor-go/main.go
@@ -54,6 +54,7 @@ func init() {
 	rootCmd.PersistentFlags().Int("max-workers", 10, "Maximum number of concurrent workers")
 	rootCmd.PersistentFlags().Float32("kube-api-qps", defaultKubeAPIQPS, "Kubernetes API client QPS limit (set 0 to use client-go default)")
 	rootCmd.PersistentFlags().Int("kube-api-burst", defaultKubeAPIBurst, "Kubernetes API client burst limit (set 0 to use 2x QPS when QPS is set, otherwise client-go default)")
+	rootCmd.PersistentFlags().Int64("list-page-limit", 100, "Maximum number of resources to request per paginated Kubernetes list call")
 	rootCmd.PersistentFlags().String("kubeconfig", "", "Path to kubeconfig file (optional)")
 
 	// Bind flags to viper
@@ -133,6 +134,7 @@ func run(_ *cobra.Command, _ []string) error {
 		ExcludeNamespaces: viper.GetStringSlice("exclude-namespaces"),
 		RulesFile:         viper.GetString("rules-file"),
 		MaxWorkers:        viper.GetInt("max-workers"),
+		ListPageLimit:     getListPageLimit(),
 	}
 
 	j, err := janitor.New(clientset, config, janitorConfig)
@@ -180,6 +182,15 @@ func configureKubeAPIClient(config *rest.Config) {
 		"qps":   config.QPS,
 		"burst": config.Burst,
 	}).Info("Configured Kubernetes API client rate limits")
+}
+
+func getListPageLimit() int64 {
+	limit := viper.GetInt64("list-page-limit")
+	if limit <= 0 {
+		logrus.WithField("list_page_limit", limit).Warn("Invalid list page limit, using default")
+		return 100
+	}
+	return limit
 }
 
 func main() {

--- a/cmd/kube-janitor-go/main_test.go
+++ b/cmd/kube-janitor-go/main_test.go
@@ -113,9 +113,9 @@ func TestRunRateLimitsJanitorPaginatedResourceListRequests(t *testing.T) {
 			})
 			requestCount := len(podListRequests)
 			elapsedSinceFirstRequest := time.Since(podListRequests[0].timestamp)
-			podIds := make([]int, listPageLimit)
-			for i := range podIds {
-				podIds[i] = podCounter + i
+			podIDs := make([]int, listPageLimit)
+			for i := range podIDs {
+				podIDs[i] = podCounter + i
 			}
 			podCounter += listPageLimit
 			mu.Unlock()
@@ -142,7 +142,7 @@ func TestRunRateLimitsJanitorPaginatedResourceListRequests(t *testing.T) {
 			if requestCount < podCount {
 				nextContinueToken = fmt.Sprintf("page-%d", requestCount)
 			}
-			_, _ = w.Write([]byte(podListJSON(nextContinueToken, includedNamespaces, ignoredNamespace, podIds, ttlThreshold)))
+			_, _ = w.Write([]byte(podListJSON(nextContinueToken, includedNamespaces, ignoredNamespace, podIDs, ttlThreshold)))
 		case r.Method == http.MethodDelete && podDeletePath.MatchString(r.URL.Path):
 			match := podDeletePath.FindStringSubmatch(r.URL.Path)
 			mu.Lock()
@@ -257,17 +257,17 @@ users:
 	return kubeconfig
 }
 
-func podListJSON(continueToken string, includedNamespaces []string, ignoredNamespace string, podIds []int, ttlThreshold int) string {
-	items := make([]string, 0, len(podIds))
-	for _, podId := range podIds {
+func podListJSON(continueToken string, includedNamespaces []string, ignoredNamespace string, podIDs []int, ttlThreshold int) string {
+	items := make([]string, 0, len(podIDs))
+	for _, podID := range podIDs {
 		var namespace string
-		if podId%10 == 0 {
+		if podID%10 == 0 {
 			namespace = ignoredNamespace
 		} else {
-			namespace = includedNamespaces[podId%len(includedNamespaces)]
+			namespace = includedNamespaces[podID%len(includedNamespaces)]
 		}
 		ttl := "100w"
-		if podId >= ttlThreshold {
+		if podID >= ttlThreshold {
 			ttl = "1ns"
 		}
 		items = append(items, fmt.Sprintf(`{
@@ -279,7 +279,7 @@ func podListJSON(continueToken string, includedNamespaces []string, ignoredNames
 				"creationTimestamp": "2026-01-01T00:00:00Z",
 				"annotations": {"janitor/ttl": %q}
 			}
-		}`, podId, namespace, ttl))
+		}`, podID, namespace, ttl))
 	}
 
 	return fmt.Sprintf(`{

--- a/cmd/kube-janitor-go/main_test.go
+++ b/cmd/kube-janitor-go/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -44,28 +45,33 @@ func TestConfigureKubeAPIClientAllowsClientGoDefaults(t *testing.T) {
 	assert.Zero(t, config.Burst)
 }
 
-func TestRunRateLimitsJanitorResourceListRequests(t *testing.T) {
+func TestRunRateLimitsJanitorPaginatedResourceListRequests(t *testing.T) {
 	const (
-		qps   = 4.0
-		burst = 1
+		qps              = 25.0
+		burst            = 1
+		listPageLimit    = 1
+		podCount         = 100
+		ttlThreshold     = 50
+		maxRuntime       = 15 * time.Second
+		ignoredNamespace = "ignored-namespace"
 	)
 
-	allNamespaces := []string{
+	includedNamespaces := []string{
 		"workspace-0",
 		"workspace-1",
 		"workspace-2",
 		"workspace-3",
 		"workspace-4",
 		"workspace-5",
-		"ignored-workspace",
 	}
-	includedNamespaces := allNamespaces[:6]
+
+	podDeletePath := regexp.MustCompile(`^/api/v1/namespaces/([^/]+)/pods/([^/]+)$`)
 
 	var mu sync.Mutex
-	var podListTimestamps []time.Time
-	var podListNamespaces []string
+	var podListRequests []podListRequest
+	var deletedPodNames []string
+	podCounter := 0
 
-	podListPath := regexp.MustCompile(`^/api/v1/namespaces/([^/]+)/pods$`)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -98,20 +104,57 @@ func TestRunRateLimitsJanitorResourceListRequests(t *testing.T) {
 					}
 				]
 			}`))
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/namespaces":
-			_, _ = w.Write([]byte(namespaceListJSON(allNamespaces)))
-		case r.Method == http.MethodGet && podListPath.MatchString(r.URL.Path):
-			namespace := podListPath.FindStringSubmatch(r.URL.Path)[1]
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/pods":
 			mu.Lock()
-			podListTimestamps = append(podListTimestamps, time.Now())
-			podListNamespaces = append(podListNamespaces, namespace)
+			podListRequests = append(podListRequests, podListRequest{
+				timestamp:     time.Now(),
+				limit:         r.URL.Query().Get("limit"),
+				continueToken: r.URL.Query().Get("continue"),
+			})
+			requestCount := len(podListRequests)
+			elapsedSinceFirstRequest := time.Since(podListRequests[0].timestamp)
+			podIds := make([]int, listPageLimit)
+			for i := range podIds {
+				podIds[i] = podCounter + i
+			}
+			podCounter += listPageLimit
 			mu.Unlock()
 
-			_, _ = w.Write([]byte(`{
-				"kind": "PodList",
-				"apiVersion": "v1",
-				"items": []
-			}`))
+			if elapsedSinceFirstRequest > maxRuntime {
+				http.Error(w, "pod list requests exceeded maximum runtime", http.StatusRequestTimeout)
+				return
+			}
+
+			expectedContinueToken := ""
+			if requestCount > 1 {
+				expectedContinueToken = fmt.Sprintf("page-%d", requestCount-1)
+			}
+			if r.URL.Query().Get("continue") != expectedContinueToken {
+				http.Error(w, "unexpected continue token", http.StatusBadRequest)
+				return
+			}
+			if requestCount > podCount {
+				http.Error(w, "too many pod list requests", http.StatusBadRequest)
+				return
+			}
+
+			nextContinueToken := ""
+			if requestCount < podCount {
+				nextContinueToken = fmt.Sprintf("page-%d", requestCount)
+			}
+			_, _ = w.Write([]byte(podListJSON(nextContinueToken, includedNamespaces, ignoredNamespace, podIds, ttlThreshold)))
+		case r.Method == http.MethodDelete && podDeletePath.MatchString(r.URL.Path):
+			match := podDeletePath.FindStringSubmatch(r.URL.Path)
+			mu.Lock()
+			deletedPodNames = append(deletedPodNames, match[2])
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Success"}`))
+		case strings.Contains(r.URL.Path, "/events"):
+			_, _ = io.Copy(io.Discard, r.Body)
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusCreated)
+			}
+			_, _ = w.Write([]byte(`{"kind":"Event","apiVersion":"v1","metadata":{"name":"ev","namespace":"default","resourceVersion":"1"},"involvedObject":{},"reason":"x","message":"x","type":"Normal"}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -126,7 +169,7 @@ func TestRunRateLimitsJanitorResourceListRequests(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
 	viper.Set("once", true)
-	viper.Set("dry-run", true)
+	viper.Set("dry-run", false)
 	viper.Set("metrics-port", 0)
 	viper.Set("kubeconfig", kubeconfig)
 	viper.Set("include-resources", []string{"pods"})
@@ -134,6 +177,7 @@ func TestRunRateLimitsJanitorResourceListRequests(t *testing.T) {
 	viper.Set("exclude-resources", []string{})
 	viper.Set("exclude-namespaces", []string{})
 	viper.Set("max-workers", 1)
+	viper.Set("list-page-limit", int64(listPageLimit))
 	viper.Set("log-level", "info")
 	viper.Set("kube-api-qps", qps)
 	viper.Set("kube-api-burst", burst)
@@ -142,22 +186,50 @@ func TestRunRateLimitsJanitorResourceListRequests(t *testing.T) {
 	require.NoError(t, run(rootCmd, nil))
 
 	mu.Lock()
-	gotTimestamps := append([]time.Time(nil), podListTimestamps...)
-	gotNamespaces := append([]string(nil), podListNamespaces...)
+	gotPodListRequests := append([]podListRequest(nil), podListRequests...)
+	gotDeletedPodNames := append([]string(nil), deletedPodNames...)
 	mu.Unlock()
 
-	require.Len(t, gotTimestamps, len(includedNamespaces))
-	assert.ElementsMatch(t, includedNamespaces, gotNamespaces)
-	assert.NotContains(t, gotNamespaces, "ignored-workspace")
+	require.Len(t, gotPodListRequests, podCount)
+	for i, request := range gotPodListRequests {
+		assert.Equal(t, fmt.Sprintf("%d", listPageLimit), request.limit)
 
-	sort.Slice(gotTimestamps, func(i, j int) bool {
-		return gotTimestamps[i].Before(gotTimestamps[j])
+		if i == 0 {
+			assert.Empty(t, request.continueToken)
+		} else {
+			assert.Equal(t, fmt.Sprintf("page-%d", i), request.continueToken)
+		}
+	}
+
+	sort.Slice(gotPodListRequests, func(i, j int) bool {
+		return gotPodListRequests[i].timestamp.Before(gotPodListRequests[j].timestamp)
 	})
 
-	span := gotTimestamps[len(gotTimestamps)-1].Sub(gotTimestamps[0])
-	expectedMinimum := time.Duration(float64(len(includedNamespaces)-burst) / qps * float64(time.Second))
+	span := gotPodListRequests[len(gotPodListRequests)-1].timestamp.Sub(gotPodListRequests[0].timestamp)
+	expectedMinimum := time.Duration(float64(podCount-burst) / qps * float64(time.Second))
 
 	assert.GreaterOrEqual(t, span, expectedMinimum-200*time.Millisecond)
+	assert.LessOrEqual(t, span, maxRuntime)
+
+	var expectedDeletions []string
+	for id := 0; id < podCount; id++ {
+		if id%10 != 0 && id >= ttlThreshold {
+			expectedDeletions = append(expectedDeletions, fmt.Sprintf("pod-%d", id))
+		}
+	}
+	assert.ElementsMatch(t, expectedDeletions, gotDeletedPodNames,
+		"only pods past the TTL threshold and not in the ignored namespace should have been deleted")
+
+	for id := 0; id < podCount; id += 10 {
+		assert.NotContains(t, gotDeletedPodNames, fmt.Sprintf("pod-%d", id),
+			"pod-%d is in the ignored namespace and must never be deleted", id)
+	}
+}
+
+type podListRequest struct {
+	timestamp     time.Time
+	limit         string
+	continueToken string
 }
 
 func writeTestKubeconfig(t *testing.T, serverURL string) string {
@@ -185,15 +257,37 @@ users:
 	return kubeconfig
 }
 
-func namespaceListJSON(namespaces []string) string {
-	items := make([]string, 0, len(namespaces))
-	for _, namespace := range namespaces {
-		items = append(items, fmt.Sprintf(`{"metadata":{"name":%q}}`, namespace))
+func podListJSON(continueToken string, includedNamespaces []string, ignoredNamespace string, podIds []int, ttlThreshold int) string {
+	items := make([]string, 0, len(podIds))
+	for _, podId := range podIds {
+		var namespace string
+		if podId%10 == 0 {
+			namespace = ignoredNamespace
+		} else {
+			namespace = includedNamespaces[podId%len(includedNamespaces)]
+		}
+		ttl := "100w"
+		if podId >= ttlThreshold {
+			ttl = "1ns"
+		}
+		items = append(items, fmt.Sprintf(`{
+			"apiVersion": "v1",
+			"kind": "Pod",
+			"metadata": {
+				"name": "pod-%d",
+				"namespace": %q,
+				"creationTimestamp": "2026-01-01T00:00:00Z",
+				"annotations": {"janitor/ttl": %q}
+			}
+		}`, podId, namespace, ttl))
 	}
 
 	return fmt.Sprintf(`{
-		"kind": "NamespaceList",
+		"kind": "PodList",
 		"apiVersion": "v1",
+		"metadata": {
+			"continue": %q
+		},
 		"items": [%s]
-	}`, strings.Join(items, ","))
+	}`, continueToken, strings.Join(items, ","))
 }

--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -95,6 +95,9 @@ spec:
           - --exclude-namespaces=kube-system,kube-public,kube-node-lease,kube-janitor
           - --rules-file=/config/rules.yaml
           - --log-level=info
+          - --kube-api-qps=25
+          - --kube-api-burst=50
+          - --list-page-limit=100
         resources:
           requests:
             memory: "64Mi"

--- a/helm/kube-janitor-go/templates/_helpers.tpl
+++ b/helm/kube-janitor-go/templates/_helpers.tpl
@@ -73,6 +73,7 @@ Build the command-line arguments for kube-janitor-go
 {{- $args = append $args (printf "--log-level=%s" .Values.janitor.logLevel) }}
 {{- $args = append $args (printf "--max-workers=%d" (int .Values.janitor.maxWorkers)) }}
 {{- $args = append $args (printf "--metrics-port=%d" (int .Values.metrics.port)) }}
+{{- $args = append $args (printf "--list-page-limit=%d" (int .Values.janitor.listPageLimit)) }}
 {{- if and (hasKey .Values.janitor "kubeAPIQPS") (ne .Values.janitor.kubeAPIQPS nil) }}
 {{- $args = append $args (printf "--kube-api-qps=%v" .Values.janitor.kubeAPIQPS) }}
 {{- end }}

--- a/helm/kube-janitor-go/values.yaml
+++ b/helm/kube-janitor-go/values.yaml
@@ -74,6 +74,9 @@ janitor:
 
   # Kubernetes API client burst limit (set to 0 to use 2x QPS when QPS is set, otherwise client-go default)
   kubeAPIBurst: 50
+
+  # Maximum number of resources to request per paginated Kubernetes list call
+  listPageLimit: 100
   
   # Resource types to include (empty means all)
   includeResources: []

--- a/internal/janitor/janitor.go
+++ b/internal/janitor/janitor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -61,6 +62,7 @@ type Config struct {
 	ExcludeNamespaces []string
 	RulesFile         string
 	MaxWorkers        int
+	ListPageLimit     int64
 }
 
 // Janitor is the main cleanup controller
@@ -123,7 +125,7 @@ func New(clientset kubernetes.Interface, restConfig *rest.Config, config Config)
 		Config:          config,
 		RuleEngine:      ruleEngine,
 		ResourceFilter:  resourceFilter,
-		WorkQueue:       make(chan WorkItem, 1000),
+		WorkQueue:       make(chan WorkItem, 2000),
 		wg:              sync.WaitGroup{},
 		EventRecorder:   recorder,
 	}, nil
@@ -216,34 +218,9 @@ func (j *Janitor) cleanup(ctx context.Context) error {
 				Resource: resource.Name,
 			}
 
-			// Process namespaced resources
-			if resource.Namespaced {
-				namespaces, err := j.getNamespaces(ctx)
-				if err != nil {
-					logrus.WithError(err).Error("Failed to list namespaces")
-					metrics.Errors.WithLabelValues("list_namespaces").Inc()
-					continue
-				}
-
-				for _, ns := range namespaces {
-					if !j.ResourceFilter.ShouldProcessNamespace(ns) {
-						continue
-					}
-
-					if err := j.processResources(ctx, gvr, ns); err != nil {
-						logrus.WithError(err).WithFields(logrus.Fields{
-							"resource":  resource.Name,
-							"namespace": ns,
-						}).Error("Failed to process resources")
-						metrics.Errors.WithLabelValues("process_resources").Inc()
-					}
-				}
-			} else {
-				// Process cluster-scoped resources
-				if err := j.processResources(ctx, gvr, ""); err != nil {
-					logrus.WithError(err).WithField("resource", resource.Name).Error("Failed to process resources")
-					metrics.Errors.WithLabelValues("process_resources").Inc()
-				}
+			if err := j.processResources(ctx, gvr, resource.Namespaced); err != nil {
+				logrus.WithError(err).WithField("resource", resource.Name).Error("Failed to process resources")
+				metrics.Errors.WithLabelValues("process_resources").Inc()
 			}
 		}
 	}
@@ -252,33 +229,46 @@ func (j *Janitor) cleanup(ctx context.Context) error {
 	return nil
 }
 
-func (j *Janitor) processResources(ctx context.Context, gvr schema.GroupVersionResource, namespace string) error {
-	var resourceInterface dynamic.ResourceInterface
-	if namespace != "" {
-		resourceInterface = j.DynamicClient.Resource(gvr).Namespace(namespace)
-	} else {
-		resourceInterface = j.DynamicClient.Resource(gvr)
-	}
+func (j *Janitor) processResources(ctx context.Context, gvr schema.GroupVersionResource, namespaced bool) error {
+	resourceInterface := j.DynamicClient.Resource(gvr)
+	listOptions := metav1.ListOptions{Limit: j.Config.ListPageLimit}
+	restartedAfterExpiry := false
 
-	list, err := resourceInterface.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-
-	for _, item := range list.Items {
-		obj := item
-		// Track evaluated resources
-		metrics.ResourcesEvaluated.WithLabelValues(gvr.Resource, namespace).Inc()
-
-		j.WorkQueue <- WorkItem{
-			Resource:  gvr,
-			Namespace: namespace,
-			Name:      obj.GetName(),
-			Obj:       &obj,
+	for {
+		list, err := resourceInterface.List(ctx, listOptions)
+		if err != nil {
+			if apierrors.IsResourceExpired(err) && !restartedAfterExpiry {
+				logrus.WithError(err).WithField("resource", gvr.Resource).Warn("Continue token expired, restarting paginated list")
+				listOptions.Continue = ""
+				restartedAfterExpiry = true
+				continue
+			}
+			return err
 		}
-	}
 
-	return nil
+		for _, item := range list.Items {
+			obj := item
+			namespace := obj.GetNamespace()
+			if namespaced && !j.ResourceFilter.ShouldProcessNamespace(namespace) {
+				continue
+			}
+
+			// Track evaluated resources
+			metrics.ResourcesEvaluated.WithLabelValues(gvr.Resource, namespace).Inc()
+
+			j.WorkQueue <- WorkItem{
+				Resource:  gvr,
+				Namespace: namespace,
+				Name:      obj.GetName(),
+				Obj:       &obj,
+			}
+		}
+
+		if list.GetContinue() == "" {
+			return nil
+		}
+		listOptions.Continue = list.GetContinue()
+	}
 }
 
 func (j *Janitor) worker(ctx context.Context) {
@@ -672,17 +662,24 @@ func (j *Janitor) shouldDelete(obj *unstructured.Unstructured) (bool, string) {
 }
 
 func (j *Janitor) getNamespaces(ctx context.Context) ([]string, error) {
-	namespaceList, err := j.Clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
+	var namespaces []string
+	listOptions := metav1.ListOptions{Limit: j.Config.ListPageLimit}
 
-	namespaces := make([]string, 0, len(namespaceList.Items))
-	for _, ns := range namespaceList.Items {
-		namespaces = append(namespaces, ns.Name)
-	}
+	for {
+		namespaceList, err := j.Clientset.CoreV1().Namespaces().List(ctx, listOptions)
+		if err != nil {
+			return nil, err
+		}
 
-	return namespaces, nil
+		for _, ns := range namespaceList.Items {
+			namespaces = append(namespaces, ns.Name)
+		}
+
+		if namespaceList.GetContinue() == "" {
+			return namespaces, nil
+		}
+		listOptions.Continue = namespaceList.GetContinue()
+	}
 }
 
 func parseExpirationTime(expires string) (time.Time, error) {

--- a/internal/janitor/janitor.go
+++ b/internal/janitor/janitor.go
@@ -253,8 +253,8 @@ func (j *Janitor) processResources(ctx context.Context, gvr schema.GroupVersionR
 				continue
 			}
 
-			// Track evaluated resources
-			metrics.ResourcesEvaluated.WithLabelValues(gvr.Resource, namespace).Inc()
+			// Track evaluated resources without namespace/workspace labels to keep metric cardinality bounded.
+			metrics.ResourcesEvaluated.WithLabelValues(gvr.Resource).Inc()
 
 			j.WorkQueue <- WorkItem{
 				Resource:  gvr,

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -11,6 +11,10 @@ import (
 )
 
 var (
+	// CleanupDurationBuckets cover cleanup runs from small clusters through
+	// large clusters where a full sweep can take many minutes.
+	CleanupDurationBuckets = []float64{1, 2.5, 5, 10, 30, 60, 120, 300, 600, 900, 1200, 1800}
+
 	// ResourcesDeleted is a counter for deleted resources
 	ResourcesDeleted = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -34,7 +38,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "kube_janitor_cleanup_duration_seconds",
 			Help:    "Histogram of cleanup run durations",
-			Buckets: prometheus.DefBuckets,
+			Buckets: CleanupDurationBuckets,
 		},
 	)
 

--- a/internal/metrics/server_test.go
+++ b/internal/metrics/server_test.go
@@ -140,7 +140,7 @@ func TestMetricsIncrement(t *testing.T) {
 		prometheus.HistogramOpts{
 			Name:    "kube_janitor_cleanup_duration_seconds_test",
 			Help:    "Histogram of cleanup run durations",
-			Buckets: prometheus.DefBuckets,
+			Buckets: CleanupDurationBuckets,
 		},
 	)
 	TTLDeletionLag = prometheus.NewHistogramVec(


### PR DESCRIPTION
The biggest bottleneck to scalability atm is the sheer number of list API calls. In PDX, there are ~2160 namespaces. There are ~8000 pods in total. That's an average of ~3.7 pods per namespace, and the janitor makes ~2160 requests (1 per namespace) at 25 QPS = 86 seconds minimum.

With this new approach, we simply list all pods in all namespaces (paginated to 100 results per request), and do some client-side namespace filtering, so we only need to make ~80 list-pods calls in total in PDX, which would only take ~4 seconds if it were to bump up against a 25 QPS limit, so the bottleneck will no longer be kube API QPS.