### PR TITLE
Use more sensible bucket cutoffs for janitor duration

### DIFF
--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -11,6 +11,10 @@ import (
 )
 
 var (
+	// CleanupDurationBuckets cover cleanup runs from small clusters through
+	// large clusters where a full sweep can take many minutes.
+	CleanupDurationBuckets = []float64{1, 2.5, 5, 10, 30, 60, 120, 300, 600, 900, 1200, 1800}
+
 	// ResourcesDeleted is a counter for deleted resources
 	ResourcesDeleted = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -34,7 +38,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "kube_janitor_cleanup_duration_seconds",
 			Help:    "Histogram of cleanup run durations",
-			Buckets: prometheus.DefBuckets,
+			Buckets: CleanupDurationBuckets,
 		},
 	)
 

--- a/internal/metrics/server_test.go
+++ b/internal/metrics/server_test.go
@@ -140,7 +140,7 @@ func TestMetricsIncrement(t *testing.T) {
 		prometheus.HistogramOpts{
 			Name:    "kube_janitor_cleanup_duration_seconds_test",
 			Help:    "Histogram of cleanup run durations",
-			Buckets: prometheus.DefBuckets,
+			Buckets: CleanupDurationBuckets,
 		},
 	)
 	TTLDeletionLag = prometheus.NewHistogramVec(


### PR DESCRIPTION
This explains why they're all capping out at 10 seconds on [the dashboard](https://blaxel.us.signoz.cloud/dashboard/019e6614-b7b1-7464-80bd-4a34d3e61cff)