### PR TITLE
Only delete resources if the UID is unchanged

### DIFF
--- a/internal/janitor/janitor.go
+++ b/internal/janitor/janitor.go
@@ -357,7 +357,7 @@ func (j *Janitor) processItem(ctx context.Context, item WorkItem) {
 		resourceInterface = j.DynamicClient.Resource(item.Resource)
 	}
 
-	err := resourceInterface.Delete(ctx, item.Name, metav1.DeleteOptions{})
+	err := resourceInterface.Delete(ctx, item.Name, deleteOptionsForObject(item.Obj))
 	if err != nil {
 		logger.WithError(err).Error("Failed to delete resource")
 		metrics.Errors.WithLabelValues("delete_resource").Inc()
@@ -382,6 +382,15 @@ func (j *Janitor) processItem(ctx context.Context, item WorkItem) {
 	eventMessage := fmt.Sprintf("Deleted %s %s/%s - %s",
 		item.Resource.Resource, item.Namespace, item.Name, decision.detailedMessage)
 	j.EventRecorder.Event(ref, corev1.EventTypeNormal, "ResourceDeleted", eventMessage)
+}
+
+func deleteOptionsForObject(obj *unstructured.Unstructured) metav1.DeleteOptions {
+	uid := obj.GetUID()
+	return metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID: &uid,
+		},
+	}
 }
 
 // evaluateDeleteIfMaxAge checks if resource should be deleted based on max age

--- a/internal/janitor/janitor_test.go
+++ b/internal/janitor/janitor_test.go
@@ -371,6 +371,7 @@ func TestProcessItem(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name":      "test-pod",
 				"namespace": "default",
+				"uid":       "test-pod-uid",
 				"annotations": map[string]interface{}{
 					annotationTTL: "0s", // Expired immediately
 				},
@@ -420,6 +421,23 @@ func TestProcessItem(t *testing.T) {
 	j.processItem(ctx, item)
 	assert.True(t, deleteCalled, "Delete should have been called")
 	assert.Equal(t, ttlLagSamplesBefore+1, ttlDeletionLagSampleCount(t, item.Resource.Resource, deletionReasonLegacyTTL))
+}
+
+func TestDeleteOptionsForObjectUsesUIDPrecondition(t *testing.T) {
+	pod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "test-pod",
+				"uid":  "test-pod-uid",
+			},
+		},
+	}
+
+	deleteOptions := deleteOptionsForObject(pod)
+
+	require.NotNil(t, deleteOptions.Preconditions)
+	require.NotNil(t, deleteOptions.Preconditions.UID)
+	assert.Equal(t, pod.GetUID(), *deleteOptions.Preconditions.UID)
 }
 
 func TestProcessItemDryRun(t *testing.T) {


### PR DESCRIPTION
This addresses a potential edge case, which has always existed for the janitor, where:

1. The janitor lists resource N/X (namespace = N, name = X) and marks it for deletion, puts it in the queue.
2. Some user deletes N/X, then creates a new resource called X in N.
3. The janitor deletes N/X by name, even though N/X now refers to a different resource than the one that was originally scanned.

Unlike the name, which can be re-used, the UID will not be re-used.