### PR TITLE
Also tag binary builds with the commit hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,19 +72,26 @@ jobs:
       - name: Set image tags
         id: set-tags
         run: |
+          # Tag the image using an abbreviated (8-character) commit hash of build head.
+          echo "GHCR_COMMIT_TAG=ghcr.io/${{ github.repository }}:${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+
+          # Also tag it with either 'latest' or 'latest-preview',
+          # although these tags should not be used in production because they make rolling back more complicated.
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "GHCR_TAG=ghcr.io/${{ github.repository }}:latest" >> $GITHUB_OUTPUT
+            echo "GHCR_LATEST_TAG=ghcr.io/${{ github.repository }}:latest" >> $GITHUB_OUTPUT
           else
-            echo "GHCR_TAG=ghcr.io/${{ github.repository }}:latest-preview" >> $GITHUB_OUTPUT
+            echo "GHCR_LATEST_TAG=ghcr.io/${{ github.repository }}:latest-preview" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.set-tags.outputs.GHCR_TAG }}
+          tags: |
+            ${{ steps.set-tags.outputs.GHCR_COMMIT_TAG }}
+            ${{ steps.set-tags.outputs.GHCR_LATEST_TAG }}
           build-args: |
             VERSION=${{ github.sha }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,13 +57,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        # https://github.com/docker/setup-qemu-action/releases/tag/v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        # https://github.com/docker/setup-buildx-action/releases/tag/v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        # https://github.com/docker/login-action/releases/tag/v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -84,7 +87,8 @@ jobs:
           fi
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        # https://github.com/docker/build-push-action/releases/tag/v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           push: true


### PR DESCRIPTION
This way, we can more easily roll back to a previous commit's tag if need be.